### PR TITLE
Separate file and security context

### DIFF
--- a/fileupload-web/src/main/java/fileupload/web/app/method/OwnerArgumentResolver.java
+++ b/fileupload-web/src/main/java/fileupload/web/app/method/OwnerArgumentResolver.java
@@ -1,0 +1,32 @@
+package fileupload.web.app.method;
+
+import fileupload.web.file.Owner;
+import fileupload.web.security.AccountUserDetails;
+import fileupload.web.user.UserAccount;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class OwnerArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return Owner.class.isAssignableFrom(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication.getPrincipal() instanceof AccountUserDetails) {
+            AccountUserDetails details = AccountUserDetails.class.cast(authentication.getPrincipal());
+            UserAccount account = details.getAccount();
+            return new Owner(account.getId());
+        } else {
+            return null;
+        }
+    }
+}

--- a/fileupload-web/src/main/java/fileupload/web/config/CustomWebMvcConfigurer.java
+++ b/fileupload-web/src/main/java/fileupload/web/config/CustomWebMvcConfigurer.java
@@ -1,0 +1,17 @@
+package fileupload.web.config;
+
+import fileupload.web.app.method.OwnerArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class CustomWebMvcConfigurer implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new OwnerArgumentResolver());
+    }
+}

--- a/fileupload-web/src/main/java/fileupload/web/file/FileRepository.java
+++ b/fileupload-web/src/main/java/fileupload/web/file/FileRepository.java
@@ -1,16 +1,14 @@
 package fileupload.web.file;
 
-import fileupload.web.user.UserAccount;
-
 import java.util.List;
 
 public interface FileRepository {
 
-    public List<StoredFile> searchRoot(UserAccount user);
+    public List<StoredFile> searchRoot(Owner owner);
 
-    public List<StoredFile> search(String parentDirId, UserAccount user);
+    public List<StoredFile> search(String parentDirId, Owner owner);
 
-    public StoredFile findById(String id, UserAccount user);
+    public StoredFile findById(String id, Owner owner);
 
     public void save(StoredFile file);
 }

--- a/fileupload-web/src/main/java/fileupload/web/file/FileService.java
+++ b/fileupload-web/src/main/java/fileupload/web/file/FileService.java
@@ -1,6 +1,5 @@
 package fileupload.web.file;
 
-import fileupload.web.user.UserAccount;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,17 +35,17 @@ public class FileService {
     }
 
     @Transactional(readOnly = true)
-    public List<StoredFile> searchRoot(UserAccount user) {
-        return fileRepository.searchRoot(user);
+    public List<StoredFile> searchRoot(Owner owner) {
+        return fileRepository.searchRoot(owner);
     }
 
     @Transactional(readOnly = true)
-    public List<StoredFile> search(String parentId, UserAccount user) {
-        return fileRepository.search(parentId, user);
+    public List<StoredFile> search(String parentId, Owner owner) {
+        return fileRepository.search(parentId, owner);
     }
 
     @Transactional(rollbackFor = Exception.class)
-    public void register(MultipartFile multipartFile, Path parentPath, UserAccount account) {
+    public void register(MultipartFile multipartFile, Path parentPath, Owner owner) {
         // TODO MultipartFileに依存しないようにする
 
         try (InputStream in = multipartFile.getInputStream()) {
@@ -62,7 +61,7 @@ public class FileService {
 
             fileRepository.save(file);
 
-            fileOwnershipRepository.create(fileId, account.getId(), "READ_AND_WRITE");
+            fileOwnershipRepository.create(fileId, owner.getId(), "READ_AND_WRITE");
 
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -70,8 +69,8 @@ public class FileService {
     }
 
     @Transactional(readOnly = true)
-    public StoredFile findById(String fileId, UserAccount user) {
-        return fileRepository.findById(fileId, user);
+    public StoredFile findById(String fileId, Owner owner) {
+        return fileRepository.findById(fileId, owner);
     }
 
     @Transactional(readOnly = true)
@@ -86,7 +85,7 @@ public class FileService {
     }
 
     @Transactional(rollbackFor = Exception.class)
-    public void createDirectory(String name, Path parentPath, UserAccount account) {
+    public void createDirectory(String name, Path parentPath, Owner owner) {
         var fileId = UUID.randomUUID();
         var file = new StoredFile(
                 fileId,
@@ -99,7 +98,7 @@ public class FileService {
 
         fileRepository.save(file);
 
-        fileOwnershipRepository.create(fileId, account.getId(), "READ_AND_WRITE");
+        fileOwnershipRepository.create(fileId, owner.getId(), "READ_AND_WRITE");
     }
 
     @Transactional(rollbackFor = Exception.class)

--- a/fileupload-web/src/main/java/fileupload/web/file/Owner.java
+++ b/fileupload-web/src/main/java/fileupload/web/file/Owner.java
@@ -1,0 +1,16 @@
+package fileupload.web.file;
+
+import java.util.UUID;
+
+public class Owner {
+
+    private UUID id;
+
+    public Owner(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+}

--- a/fileupload-web/src/main/java/fileupload/web/file/infra/JdbcFileRepository.java
+++ b/fileupload-web/src/main/java/fileupload/web/file/infra/JdbcFileRepository.java
@@ -2,8 +2,8 @@ package fileupload.web.file.infra;
 
 import fileupload.web.file.FileRepository;
 import fileupload.web.file.FileType;
+import fileupload.web.file.Owner;
 import fileupload.web.file.StoredFile;
-import fileupload.web.user.UserAccount;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -22,13 +22,13 @@ public class JdbcFileRepository implements FileRepository {
     }
 
     @Override
-    public List<StoredFile> searchRoot(UserAccount user) {
+    public List<StoredFile> searchRoot(Owner owner) {
         return jdbcTemplate.query(
                 "SELECT id, name, path, type, size " +
                         "FROM file " +
                         "WHERE cast(id as text) = replace(path, '/', '') " +
                         "AND id IN(SELECT file_id FROM file_ownership WHERE owned_at = ?)",
-                ps -> ps.setObject(1, user.getId()),
+                ps -> ps.setObject(1, owner.getId()),
                 (rs, rowNum) -> {
                     return new StoredFile(UUID.fromString(rs.getString("id"))
                             , rs.getString("name")
@@ -39,7 +39,7 @@ public class JdbcFileRepository implements FileRepository {
     }
 
     @Override
-    public List<StoredFile> search(String parentDirId, UserAccount user) {
+    public List<StoredFile> search(String parentDirId, Owner owner) {
 
         // TODO levelを使わない方法にリファクタリングする。
         int level = getLevel(parentDirId);
@@ -52,7 +52,7 @@ public class JdbcFileRepository implements FileRepository {
                 ps -> {
                     ps.setString(1, parentDirId);
                     ps.setInt(2, level);
-                    ps.setObject(3, user.getId());
+                    ps.setObject(3, owner.getId());
                 },
                 (rs, rowNum) -> {
                     return new StoredFile(UUID.fromString(rs.getString("id"))
@@ -71,7 +71,7 @@ public class JdbcFileRepository implements FileRepository {
     }
 
     @Override
-    public StoredFile findById(String id, UserAccount user) {
+    public StoredFile findById(String id, Owner owner) {
         return jdbcTemplate.query(
                 "SELECT id, name, path, type, content, size FROM file WHERE LOWER(id) = LOWER(?) " +
                         "AND id IN(SELECT file_id FROM file_ownership WHERE owned_at = ?)",
@@ -88,7 +88,7 @@ public class JdbcFileRepository implements FileRepository {
                         return null;
                     }
                 },
-                id, user.getId());
+                id, owner.getId());
     }
 
     @Override

--- a/fileupload-web/src/main/java/fileupload/web/file/web/StoredFileDownloadView.java
+++ b/fileupload-web/src/main/java/fileupload/web/file/web/StoredFileDownloadView.java
@@ -18,7 +18,6 @@ public class StoredFileDownloadView extends AbstractView {
     @Override
     protected void renderMergedOutputModel(Map<String, Object> map, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception {
 
-
         StoredFile downloadFile = (StoredFile) map.get("downloadFile");
 
         // TODO 半角スペースが+に置換されてしまう

--- a/fileupload-web/src/main/java/fileupload/web/file/web/UploadController.java
+++ b/fileupload-web/src/main/java/fileupload/web/file/web/UploadController.java
@@ -19,8 +19,6 @@ import java.util.Optional;
 @RequestMapping("file")
 public class UploadController {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
-
     final FileService fileService;
 
     public UploadController(FileService fileService) {

--- a/fileupload-web/src/test/java/fileupload/web/file/infra/JdbcFileRepositoryTest.java
+++ b/fileupload-web/src/test/java/fileupload/web/file/infra/JdbcFileRepositoryTest.java
@@ -3,9 +3,9 @@ package fileupload.web.file.infra;
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import fileupload.web.file.FileType;
+import fileupload.web.file.Owner;
 import fileupload.web.file.StoredFile;
 import fileupload.web.test.annotation.DatabaseRiderTest;
-import fileupload.web.user.UserAccount;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -51,13 +51,8 @@ class JdbcFileRepositoryTest {
         @DataSet("fileupload/web/file/infra/JdbcFileRepositoryTest-data/SearchRootTest/setup-testFindOne.yml")
         @DisplayName("Root配下のFileが1つの場合は1つ取得する")
         void testFindOne() {
-            UserAccount user = new UserAccount(
-                    UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11"),
-                    "email",
-                    "name",
-                    "password",
-                    "role");
-            List<StoredFile> actual = sut.searchRoot(user);
+            var owner = new Owner(UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11"));
+            List<StoredFile> actual = sut.searchRoot(owner);
             assertEquals(1, actual.size());
         }
 
@@ -65,13 +60,8 @@ class JdbcFileRepositoryTest {
         @DataSet("fileupload/web/file/infra/JdbcFileRepositoryTest-data/SearchRootTest/setup-testFindThree.yml")
         @DisplayName("Root配下のFileが3つの場合は3つ取得する")
         void testFindThree() {
-            UserAccount user = new UserAccount(
-                    UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A13"),
-                    "email",
-                    "name",
-                    "password",
-                    "role");
-            List<StoredFile> actual = sut.searchRoot(user);
+            var owner = new Owner(UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A13"));
+            List<StoredFile> actual = sut.searchRoot(owner);
             assertEquals(3, actual.size());
         }
     }
@@ -87,52 +77,32 @@ class JdbcFileRepositoryTest {
         @Test
         @DisplayName("指定したFolder配下のFileが1つの場合は1つ取得する")
         void testFindOne() {
-            UserAccount user = new UserAccount(
-                    UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A13"),
-                    "email",
-                    "name",
-                    "password",
-                    "role");
-            List<StoredFile> actual = sut.search("A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380B13", user);
+            var owner = new Owner(UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A13"));
+            List<StoredFile> actual = sut.search("A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380B13", owner);
             assertEquals(1, actual.size());
         }
 
         @Test
         @DisplayName("指定したFolder配下のFileが3つの場合は3つ取得する")
         void testFindThree() {
-            UserAccount user = new UserAccount(
-                    UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A14"),
-                    "email",
-                    "name",
-                    "password",
-                    "role");
-            List<StoredFile> actual = sut.search("A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11", user);
+            var owner = new Owner(UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A14"));
+            List<StoredFile> actual = sut.search("A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11", owner);
             assertEquals(3, actual.size());
         }
 
         @Test
         @DisplayName("指定したFolder配下にFileが存在しない場合は空のListを返す")
         void testFindZero() {
-            UserAccount user = new UserAccount(
-                    UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A13"),
-                    "email",
-                    "name",
-                    "password",
-                    "role");
-            List<StoredFile> actual = sut.search("A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380B12", user);
+            var owner = new Owner(UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A13"));
+            List<StoredFile> actual = sut.search("A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380B12", owner);
             assertEquals(0, actual.size());
         }
 
         @Test
         @DisplayName("指定したFileのtypeがFileだった場合は例外が発生する")
         void testSearchFile() {
-            UserAccount user = new UserAccount(
-                    UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A13"),
-                    "email",
-                    "name",
-                    "password",
-                    "role");
-            List<StoredFile> actual = sut.search("A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12", user);
+            var owner = new Owner(UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A13"));
+            List<StoredFile> actual = sut.search("A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12", owner);
             assertEquals(0, actual.size());
         }
     }
@@ -142,14 +112,13 @@ class JdbcFileRepositoryTest {
     @DatabaseRiderTest
     @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
     @DataSet("fileupload/web/file/infra/JdbcFileRepositoryTest-data/FindByIdTest/setup-findById.yml")
-    @DisplayName("findById(String,UserAccount)はUserAccountが所有するidが一致するFileを取得する")
+    @DisplayName("findById(String,Owner)はOwnerが所有するidが一致するFileを取得する")
     class FindByIdTest {
 
         @Test
         void testFindOneDirectory() {
             // given
-            UserAccount user = new UserAccount(UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A13"),
-                    "email", "name", "password", "USER");
+            var owner = new Owner(UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A13"));
             UUID fileId = UUID.fromString("A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11");
             StoredFile expected = new StoredFile(
                     fileId,
@@ -159,7 +128,7 @@ class JdbcFileRepositoryTest {
                     null,
                     0L);
             // when
-            StoredFile actual = sut.findById(fileId.toString(), user);
+            StoredFile actual = sut.findById(fileId.toString(), owner);
             // then
             assertThat(actual).isEqualToComparingFieldByField(expected);
         }
@@ -167,8 +136,7 @@ class JdbcFileRepositoryTest {
         @Test
         void testFindOneFile() throws IOException {
             // given
-            UserAccount user = new UserAccount(UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A14"),
-                    "email", "name", "password", "USER");
+            var owner = new Owner(UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A14"));
             UUID fileId = UUID.fromString("A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380B11");
             StoredFile expected = new StoredFile(
                     fileId,
@@ -178,7 +146,7 @@ class JdbcFileRepositoryTest {
                     new ByteArrayInputStream("file4 content".getBytes()),
                     3L);
             // when
-            StoredFile actual = sut.findById(fileId.toString(), user);
+            StoredFile actual = sut.findById(fileId.toString(), owner);
             // then
             assertThat(actual).isEqualToIgnoringGivenFields(expected, "content");
             assertThat(actual.getContent()).hasSameContentAs(expected.getContent());
@@ -187,8 +155,7 @@ class JdbcFileRepositoryTest {
         @Test
         void testUserNotMatched() throws IOException {
             // given
-            UserAccount user = new UserAccount(UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A13"),
-                    "email", "name", "password", "USER");
+            var owner = new Owner(UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A13"));
             UUID fileId = UUID.fromString("A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380B11");
             StoredFile expected = new StoredFile(
                     fileId,
@@ -198,7 +165,7 @@ class JdbcFileRepositoryTest {
                     new ByteArrayInputStream("file4 content".getBytes()),
                     3L);
             // when
-            StoredFile actual = sut.findById(fileId.toString(), user);
+            StoredFile actual = sut.findById(fileId.toString(), owner);
             // then
             assertThat(actual).isNull();
         }
@@ -206,8 +173,7 @@ class JdbcFileRepositoryTest {
         @Test
         void testFileNotFound() throws IOException {
             // given
-            UserAccount user = new UserAccount(UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A13"),
-                    "email", "name", "password", "USER");
+            var owner = new Owner(UUID.fromString("B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A13"));
             UUID fileId = UUID.fromString("A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380B99");
             StoredFile expected = new StoredFile(
                     fileId,
@@ -217,7 +183,7 @@ class JdbcFileRepositoryTest {
                     new ByteArrayInputStream("file4 content".getBytes()),
                     3L);
             // when
-            StoredFile actual = sut.findById(fileId.toString(), user);
+            StoredFile actual = sut.findById(fileId.toString(), owner);
             // then
             assertThat(actual).isNull();
         }


### PR DESCRIPTION
・Owner を追加。
・UserAccount を Owner にマッピングする OwnerArgumentResolver を追加。
・File集約の UserAccount への依存箇所は全て Owner に置き換えた。